### PR TITLE
Enhance Extension settings messaging; Fixed typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This extension makes available the following commands:
 
 You can define keyboard shortcuts for the often used above commands.
 
-In `Command pallet` (F1 or Ctrl + Shift + P) run the command `Preferences: Open Keyboard Shortcuts`.
+In `Command pallete` (F1 or Ctrl + Shift + P) run the command `Preferences: Open Keyboard Shortcuts`.
 In `Type to search in keybindings` type `Save and restore editors`. You can, with double click on an entry, define keyboard shortcuts for any command.
 
 An example of keyboard shortcuts can be:
@@ -57,7 +57,7 @@ For more details check [Advanced customization](https://code.visualstudio.com/do
 
 ### Save the list of all currently open editor views
 
-* From `Command pallet` (F1 or Ctrl + Shift + P) run the command `Save and restore editors: Save all open text editors`
+* From `Command pallete` (F1 or Ctrl + Shift + P) run the command `Save and restore editors: Save all open text editors`
 * Provide a name (for example: Ticket-1234) and press enter
 * The list of currently open editors is saved in `.vscode\save-restore-editors.json`
 * Commit or stash your changes
@@ -66,14 +66,14 @@ For more details check [Advanced customization](https://code.visualstudio.com/do
 ### Re-open a set of saved editors
 
 * Checkout a branch in which you want to continue your work
-* From `Command pallet` (F1 or Ctrl + Shift + P) run the command `Save and restore editors: Restore a saved set of editors`
+* From `Command pallete` (F1 or Ctrl + Shift + P) run the command `Save and restore editors: Restore a saved set of editors`
 * Pick from the list the name of the saved set correspondign to this branch
 * In addition to already open editors will be opened the files specified in choosed saved set
 
 ### Replace the list of all currently open editor views
 
 * When you need to switch again to a different branch you can replace the old set of opened editors for when you will come back
-* From `Command pallet` (F1 or Ctrl + Shift + P) run the command `Save and restore editors: Re-save all open text editors`
+* From `Command pallete` (F1 or Ctrl + Shift + P) run the command `Save and restore editors: Re-save all open text editors`
 * Pick the name of an already saved set from the list
 * The list of currently open editors is saved in `.vscode\save-restore-editors.json` overwriting the old one
 * Commit or stash your changes
@@ -81,7 +81,7 @@ For more details check [Advanced customization](https://code.visualstudio.com/do
 
 ### Replace currently open editor views and delete the saved set
 
-* From `Command pallet` (F1 or Ctrl + Shift + P) run the command `Save and restore editors: Close all and Pop (Restore+Delete) a saved set of editors`
+* From `Command pallete` (F1 or Ctrl + Shift + P) run the command `Save and restore editors: Close all and Pop (Restore+Delete) a saved set of editors`
 * All currently open editors are closed and all files specified in the saved set are open
 * The saved set is removed from `.vscode\save-restore-editors.json`
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "save-restore-editors",
   "displayName": "Save and restore tabs",
   "description": "Save and restore all tabs with text editors",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "icon": "images/logo.png",
   "license": "GPL-3.0",
   "publisher": "iulian-radu-at",

--- a/package.json
+++ b/package.json
@@ -76,13 +76,13 @@
           "saveRestoreEditors.allowOverwrite": {
             "type": "boolean",
             "default": false,
-            "description": "Save and restore tabs: allows overwriting of exiting saved group with the same name",
+            "description": "Allow overwriting of existing saved group with the same name",
             "scope": "resource"
           },
           "saveRestoreEditors.confirmAction": {
             "type": "boolean",
             "default": true,
-            "description": "Save and restore tabs: ask for confirmation of overwriting or deleting saved groups",
+            "description": "Ask for confirmation of overwriting or deleting saved groups",
             "scope": "resource"
           }
         }


### PR DESCRIPTION
Fixed typo `pallet` -> `palette`.
Enhanced messaging in Extension settings. Since the settings are grouped under the extension title, the redundant title is removed. Also, fixed typo in the overwrite setting, making the messaging clear.